### PR TITLE
Allow FacadeInterface from other modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
   "require-dev": {
     "phpstan/phpstan": "^1.9",
     "phpunit/phpunit": "^9.5",
-    "friendsofphp/php-cs-fixer": "^3.13"
+    "friendsofphp/php-cs-fixer": "^3.13",
+    "vimeo/psalm": "^5.1",
+    "psalm/plugin-phpunit": "^0.18.4"
   },
   "suggest": {
     "gacela-project/gacela": "Gacela helps you separate your project into modules, focusing on the application/infrastructure layer, decoupled from your domain."
@@ -47,14 +49,17 @@
     ],
     "quality": [
       "@csrun",
+      "@psalm",
       "@phpstan"
     ],
     "phpunit": [
       "./vendor/bin/phpunit"
     ],
     "static-clear-cache": [
+      "vendor/bin/psalm --clear-cache",
       "vendor/bin/phpstan clear-result-cache"
     ],
+    "psalm": "./vendor/bin/psalm",
     "phpstan": "./vendor/bin/phpstan analyze",
     "csfix": "./vendor/bin/php-cs-fixer fix",
     "csrun": "./vendor/bin/php-cs-fixer fix --dry-run"

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "phpunit/phpunit": "^9.5",
     "friendsofphp/php-cs-fixer": "^3.13",
     "vimeo/psalm": "^5.1",
+    "symfony/var-dumper": "^5.4",
     "psalm/plugin-phpunit": "^0.18.4"
   },
   "suggest": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<psalm
+        errorLevel="1"
+        phpVersion="7.4"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://getpsalm.org/schema/config"
+        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/EnforceModuleBoundariesForMethodCallRule.php
+++ b/src/EnforceModuleBoundariesForMethodCallRule.php
@@ -32,6 +32,8 @@ final class EnforceModuleBoundariesForMethodCallRule implements Rule
 
     /**
      * @param \PhpParser\Node\Expr\MethodCall $node
+     *
+     * @return list<\PHPStan\Rules\RuleError>
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/tests/EnforceModuleBoundariesForMethodCallRule/EnforceModuleBoundariesForMethodCallRuleTest.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/EnforceModuleBoundariesForMethodCallRuleTest.php
@@ -60,6 +60,17 @@ class EnforceModuleBoundariesForMethodCallRuleTest extends RuleTestCase
         );
     }
 
+    public function test_allow_using_facade_interface_from_other_modules(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixtures/ModuleA/Domain/Person.php',
+            ],
+            [
+            ]
+        );
+    }
+
     protected function getRule(): Rule
     {
         return new EnforceModuleBoundariesForMethodCallRule(

--- a/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleA/Domain/Person.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleA/Domain/Person.php
@@ -4,12 +4,22 @@ declare(strict_types=1);
 
 namespace GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleA\Domain;
 
+use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB\ModuleBFacadeInterface;
+
 use function get_class;
 
 class Person
 {
+    private ModuleBFacadeInterface $moduleBFacade;
+
+    public function __construct(ModuleBFacadeInterface $moduleBFacade)
+    {
+        $this->moduleBFacade = $moduleBFacade;
+    }
+
     public function updateName(string $string): void
     {
+        $this->moduleBFacade->aMethod();
     }
 
     public function asString(): string

--- a/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleA/Infrastructure/Command.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleA/Infrastructure/Command.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleA\Infrastructure;
 
-use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB\Facade;
+use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB\ModuleBFacade;
 use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB\NotAFacade;
 
 class Command
 {
-    public function allowedMethodCall(Facade $facade): void
+    public function allowedMethodCall(ModuleBFacade $facade): void
     {
         $facade->aMethod(); // This is allowed
     }

--- a/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleB/ModuleBFacade.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleB/ModuleBFacade.php
@@ -6,7 +6,7 @@ namespace GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodC
 
 use Gacela\Framework\AbstractFacade;
 
-class Facade extends AbstractFacade
+class ModuleBFacade extends AbstractFacade
 {
     public function aMethod(): void
     {

--- a/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleB/ModuleBFacadeInterface.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/ModuleB/ModuleBFacadeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB;
+
+interface ModuleBFacadeInterface
+{
+    public function aMethod(): void;
+}


### PR DESCRIPTION
## 📚 Description

Currently you cannot use an interface from other module's Facade.

## 🔖 Changes

- A module can use the facade of other modules by depending on the abstract contract/interface, and not the concrete final facade.
