### PR TITLE
Allow excluded callingCode

### DIFF
--- a/src/EnforceModuleBoundariesForMethodCallRule.php
+++ b/src/EnforceModuleBoundariesForMethodCallRule.php
@@ -45,22 +45,23 @@ final class EnforceModuleBoundariesForMethodCallRule implements Rule
         }
 
         $namespaceOfCallingCode = $scope->getNamespace();
+        if ($this->excludedNamespaceChecker->isExcludedNamespace($namespaceOfCallingCode)) {
+            return [];
+        }
+
         foreach ($type->getReferencedClasses() as $referencedClass) {
             if (strpos($referencedClass, 'FacadeInterface') !== false) {
                 return [];
             }
 
-            // Is this a call to code in the same module. If yes then exit.
             if ($this->moduleComparator->isSameModule($namespaceOfCallingCode, $referencedClass)) {
                 return [];
             }
 
-            // Is this a call to code in an excluded namespace. If yes then exit.
             if ($this->excludedNamespaceChecker->isExcludedNamespace($referencedClass)) {
                 return [];
             }
 
-            // Is the code from outside the app (core or vendor)? If yes then exit.
             if (!$this->moduleComparator->isInModule($referencedClass)) {
                 return [];
             }

--- a/tests/EnforceModuleBoundariesForMethodCallRule/EnforceModuleBoundariesForMethodCallRuleTest.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/EnforceModuleBoundariesForMethodCallRuleTest.php
@@ -49,6 +49,17 @@ class EnforceModuleBoundariesForMethodCallRuleTest extends RuleTestCase
         );
     }
 
+    public function test_method_call_to_excluded_namespace_from_calling_code(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixtures/Tests/ModuleA/Domain/PersonTest.php',
+            ],
+            [
+            ]
+        );
+    }
+
     public function test_method_call_to_code_from_vendor(): void
     {
         $this->analyse(
@@ -77,6 +88,7 @@ class EnforceModuleBoundariesForMethodCallRuleTest extends RuleTestCase
             new SameLevelModuleComparator("GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures"),
             new ExcludedNamespaceChecker([
                 'GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\Common',
+                'GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\Tests',
             ])
         );
     }

--- a/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/Tests/ModuleA/Domain/PersonTest.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/Tests/ModuleA/Domain/PersonTest.php
@@ -8,6 +8,8 @@ use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRul
 use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB\ModuleBFacadeInterface;
 use PHPUnit\Framework\TestCase;
 
+use function get_class;
+
 final class PersonTest extends TestCase
 {
     public function test_something(): void

--- a/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/Tests/ModuleA/Domain/PersonTest.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/Fixtures/Tests/ModuleA/Domain/PersonTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\Tests\ModuleA\Domain;
+
+use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleA\Domain\Person;
+use GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB\ModuleBFacadeInterface;
+use PHPUnit\Framework\TestCase;
+
+final class PersonTest extends TestCase
+{
+    public function test_something(): void
+    {
+        $p = new Person(
+            $this->createStub(ModuleBFacadeInterface::class)
+        );
+
+        self::assertEquals(get_class($p), $p->asString());
+    }
+}


### PR DESCRIPTION
## 📚 Description

The `excludedNamespaces` are currently working only on the referenced classes, but it would be really useful to define them also on the calling code.

## 🔖 Changes

- Allow excluding namespaces from the calling code. 
- This will prevent false positives on the tests, for example. So you can write unit tests for any class/logic at any point (especially useful to write unit tests for your isolated domain logic)
