### PR TITLE
Improve error message

### DIFF
--- a/src/EnforceModuleBoundariesForMethodCallRule.php
+++ b/src/EnforceModuleBoundariesForMethodCallRule.php
@@ -66,8 +66,14 @@ final class EnforceModuleBoundariesForMethodCallRule implements Rule
             }
         }
 
+        $message = sprintf(
+            'Method call to a different module is not allowed. Calling:%s, RefClasses:%s',
+            $namespaceOfCallingCode ?? 'null',
+            implode(',', $type->getReferencedClasses())
+        );
+
         return [
-            RuleErrorBuilder::message('Method call to a different module is not allowed.')->build(),
+            RuleErrorBuilder::message($message)->build(),
         ];
     }
 }

--- a/tests/EnforceModuleBoundariesForMethodCallRule/EnforceModuleBoundariesForMethodCallRuleTest.php
+++ b/tests/EnforceModuleBoundariesForMethodCallRule/EnforceModuleBoundariesForMethodCallRuleTest.php
@@ -21,7 +21,8 @@ class EnforceModuleBoundariesForMethodCallRuleTest extends RuleTestCase
             ],
             [
                 [
-                    'Method call to a different module is not allowed.', 19,
+                    'Method call to a different module is not allowed. Calling:GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleA\Infrastructure, RefClasses:GacelaProject\PhpstanExtension\Tests\EnforceModuleBoundariesForMethodCallRule\Fixtures\ModuleB\NotAFacade',
+                    19,
                 ],
             ]
         );


### PR DESCRIPTION
## 📚 Description

The current error message indicates that there is an error, but there is no other feedback whatsoever. 
```
Method call to a different module is not allowed.
```

## 🔖 Changes

- Added calling and reference classes to the error message

```
Method call to a different module is not allowed. Calling:...\ModuleA\Infrastructure, RefClasses:...\ModuleB\NotAFacade
```
